### PR TITLE
Logical NOT and Null comparison handling

### DIFF
--- a/src/SJsonPath-Core/SjJsonPathExpression.class.st
+++ b/src/SJsonPath-Core/SjJsonPathExpression.class.st
@@ -91,6 +91,16 @@ SjJsonPathExpression class >> or: leftExpression with: rightExpression [
 		yourself
 ]
 
+{ #category : 'instance creation' }
+SjJsonPathExpression class >> not: expression [
+	"Create logical NOT expression"
+	^ self new
+		type: #prefix;
+		operator: '!';
+		expressions: { expression beEnclosed };
+		yourself
+]
+
 { #category : 'accessing' }
 SjJsonPathExpression >> type [
 	^ type
@@ -198,6 +208,12 @@ SjJsonPathExpression >> & otherExpression [
 SjJsonPathExpression >> | otherExpression [
 	"Create a logical OR expression"
 	^ self class or: self with: otherExpression
+]
+
+{ #category : 'operators' }
+SjJsonPathExpression >> not [
+	"Create a logical NOT expression"
+	^ self class not: self
 ]
 
 { #category : 'printing' }

--- a/src/SJsonPath-Core/UndefinedObject.extension.st
+++ b/src/SJsonPath-Core/UndefinedObject.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #UndefinedObject }
+
+{ #category : #'*SJsonPath-Core' }
+UndefinedObject >> asJsonPathExpressionString [
+	^ 'null'
+]

--- a/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
+++ b/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
@@ -15,6 +15,13 @@ SjJsonPathFilterExpressionTestCase >> testBasicFilterExpression [
 ]
 
 { #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithGreaterThan [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'price' > 25).
+	self assert: path asString equals: '$.store.book[?(@.price > 25)]'
+]
+
+{ #category : 'testing' }
 SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithStringComparison [
 	| path |
 	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'category' = 'fiction').
@@ -26,4 +33,32 @@ SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithMultipleConditions
 	| path |
 	path := SjJsonPath root / 'store' / 'book' ? ((SjJsonPath current / 'price' < 15) & (SjJsonPath current / 'category' = 'fiction')).
 	self assert: path asString equals: '$.store.book[?(@.price < 15 && @.category == ''fiction'')]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNullComparison [
+	| path |
+	path := SjJsonPath root / 'bicycle' ? (SjJsonPath current / 'color' = nil).
+	self assert: path asString equals: '$.bicycle[?(@.color == null)]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithGreaterThanOrEqual [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'price' >= 20).
+	self assert: path asString equals: '$.store.book[?(@.price >= 20)]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithLessThanOrEqual [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'price' <= 10).
+	self assert: path asString equals: '$.store.book[?(@.price <= 10)]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNotEqual [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'category' ~= 'reference').
+	self assert: path asString equals: '$.store.book[?(@.category != ''reference'')]'
 ]

--- a/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
+++ b/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
@@ -62,3 +62,24 @@ SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNotEqual [
 	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'category' ~= 'reference').
 	self assert: path asString equals: '$.store.book[?(@.category != ''reference'')]'
 ]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNot [
+	| path |
+	path := SjJsonPath root / 'bicycle' ? (SjJsonPath current / 'color' = nil) not.
+	self assert: path asString equals: '$.bicycle[?(!(@.color == null))]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNotComparison [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'price' >= 20) not.
+	self assert: path asString equals: '$.store.book[?(!(@.price >= 20))]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNotMultipleConditions [
+	| path |
+	path := SjJsonPath root / 'store' / 'book' ? ((SjJsonPath current / 'price' < 15) & (SjJsonPath current / 'category' = 'fiction')) not.
+	self assert: path asString equals: '$.store.book[?(!(@.price < 15 && @.category == ''fiction''))]'
+]


### PR DESCRIPTION
This pull request adds support for logical NOT expressions in JSONPath filter expressions, improves the handling of comparisons with `nil` (null), and significantly expands test coverage for filter expression scenarios. The main focus is on enhancing logical operations and ensuring correct string representations for various filter cases.

**Logical NOT support:**

* Added a class-side method `not:` and an instance-side method `not` to `SjJsonPathExpression` to construct logical NOT expressions [[1]](diffhunk://#diff-59462c8d1a69871da9876efab331b4fd4f936dbf1bdd359ad62db3c06bf3cd75R94-R103) [[2]](diffhunk://#diff-59462c8d1a69871da9876efab331b4fd4f936dbf1bdd359ad62db3c06bf3cd75R213-R218).

**Null (nil) comparison handling:**

* Introduced an extension method `asJsonPathExpressionString` on `UndefinedObject` to ensure `nil` is rendered as `null` in JSONPath expressions.

**Expanded test coverage for filter expressions:**

* Added comprehensive tests to `SjJsonPathFilterExpressionTestCase` for greater than, greater than or equal, less than or equal, not equal, null comparison, and various logical NOT scenarios, verifying correct string output for each [[1]](diffhunk://#diff-03a8b19f76ec19382c0cc4762a3d6a155f6a8fa00642c179738a70f8680a9b01R17-R23) [[2]](diffhunk://#diff-03a8b19f76ec19382c0cc4762a3d6a155f6a8fa00642c179738a70f8680a9b01R37-R85).