### PR TITLE
Add regex matching support for JsonPath filter expressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ The core architecture is built around:
 - `src/SJsonPath-Tests/SjJsonPathTestCase.class.st`: Test suite with basic path creation tests and array slice tests
 - `src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st`: Test suite for filter expression functionality
 - `src/SJsonPath-Core/SjJsonPathFilterExpression.class.st`: Filter expression implementation for JsonPath conditions
-- `src/SJsonPath-Core/Object.extension.st`: Extension providing default `asJsonPathTokenString` implementation
+- `src/SJsonPath-Core/SjJsonPathRegex.class.st`: Regex pattern implementation for JsonPath regex matching
+- `src/SJsonPath-Core/Object.extension.st`: Extension providing default `asJsonPathTokenString` and `asJsonPathRegex` implementations
 - `src/SJsonPath-Core/String.extension.st`: Extension providing string comparison support for filter expressions
 - `src/SJsonPath-Core/Interval.extension.st`: Extension providing array slice formatting for Interval objects
 - `src/BaselineOfSJsonPath/BaselineOfSJsonPath.class.st`: Metacello baseline defining package structure and dependencies
@@ -43,6 +44,7 @@ The `SjJsonPath` class implements the following fluent API methods:
 - `/ SjJsonPath all`: Property wildcard access using dot notation (e.g., `$.store.*`)
 - `// otherPath`: Recursive/descendant search using double dot (e.g., `$.store..title`)
 - `? filterExpression`: Filter expression using conditions (e.g., `$.store.book[?(@.price < 15)]`)
+- `=~ pattern`: Regex matching in filter expressions (e.g., `$.inventory.mountain_bikes[?(@.specs.material =~ 'al')]`)
 - `asString`: Converts the JsonPath to its string representation
 
 ### Helper Methods
@@ -51,13 +53,16 @@ The `SjJsonPath` class implements the following fluent API methods:
 - `doubleDot`: Returns '..' for recursive search
 - `arrayEnclosed: index`: Returns array notation using `asJsonPathTokenString` for proper formatting
 - `Object >> asJsonPathTokenString`: Default implementation returning `self asString`
+- `Object >> asJsonPathRegex`: Default implementation creating `SjJsonPathRegex` instance
 - `Interval >> asJsonPathTokenString`: Specialized implementation for array slices (e.g., `'0:2'`)
+- `SjJsonPathRegex >> asJsonPathTokenString`: Returns the regex pattern string
 
 ### Class-side Utility Methods
 
 - `SjJsonPath class >> first: n`: Returns slice notation for first n elements (e.g., `':3'`)
 - `SjJsonPath class >> last: n`: Returns slice notation for last n elements (e.g., `'-1:'`)
 - `SjJsonPath class >> current`: Returns current context '@' for filter expressions
+- `SjJsonPathRegex class >> pattern: aString`: Creates regex pattern instance
 
 ### Filter Expression Methods
 
@@ -65,7 +70,14 @@ The `SjJsonPath` class implements the following fluent API methods:
 - `SjJsonPathFilterExpression >> > otherExpression`: Greater than comparison
 - `SjJsonPathFilterExpression >> = otherExpression`: Equality comparison (becomes '==' in JsonPath)
 - `SjJsonPathFilterExpression >> & otherExpression`: Logical AND operation (becomes '&&' in JsonPath)
+- `SjJsonPath >> =~ pattern`: Regex matching operation (becomes '=~' in JsonPath)
 - `String >> asJsonPathTokenString`: For filter expressions, wraps strings in single quotes
+
+### Regex Expression Methods
+
+- `SjJsonPathRegex >> ignoreCase`: Returns case-insensitive regex pattern with '(?i)' flag
+- `SjJsonPathRegex >> pattern`: Returns the regex pattern string
+- `SjJsonPathRegex >> asJsonPathRegex`: Returns self (identity method)
 
 ## Development Commands
 
@@ -94,14 +106,16 @@ TestSuite named: 'SJsonPath-Tests' do: [ :suite | suite run ]
 The project has implemented the complete fluent API:
 - Core `SjJsonPath` class with working fluent API methods (`/`, `@`, `//`, `?`)
 - Main test class `SjJsonPathTestCase` with methods covering basic functionality, array slice support, wildcard expressions, and first/last slice notation
-- Filter expression test class `SjJsonPathFilterExpressionTestCase` with tests for basic filter expressions, string comparisons, and multiple conditions
+- Filter expression test class `SjJsonPathFilterExpressionTestCase` with tests for basic filter expressions, string comparisons, multiple conditions, and regex matching
 - Token-based architecture for building JsonPath expressions
 - String conversion via `asString` method that concatenates all tokens
 - Array slice support through Interval objects with proper JsonPath slice notation (e.g., `[0:2]`)
 - Advanced slice support with `first:` and `last:` class methods for common slice patterns (e.g., `[:3]`, `[-1:]`)
 - Wildcard support for both property access (`$.store.*`) and array indexing (`$.store.book[*].author`) via `SjJsonPath all`
 - **Filter expression support** with `SjJsonPathFilterExpression` class implementing comparison operators (`<`, `>`, `=`) and logical operators (`&`)
+- **Regex matching support** with `SjJsonPathRegex` class implementing regex patterns (`=~`) with case-insensitive option (`ignoreCase`)
 - String extension for proper quote wrapping in filter expressions
+- Object extension for regex pattern creation via `asJsonPathRegex` protocol
 - Extensible token string conversion system via `asJsonPathTokenString` protocol
 
 ## Package Structure
@@ -109,3 +123,43 @@ The project has implemented the complete fluent API:
 The project uses Pharo's Tonel format (.st files) organized in package directories. Each package contains:
 - `package.st`: Package declaration
 - `*.class.st`: Class definitions in Tonel format
+
+## Examples
+
+### Basic JsonPath Construction
+```smalltalk
+"Simple property access"
+SjJsonPath root / 'store' / 'book' asString "=> '$.store.book'"
+
+"Array indexing"
+SjJsonPath root / 'users' @ 0 asString "=> '$.users[0]'"
+
+"Wildcard access"
+SjJsonPath root / 'store' / SjJsonPath all asString "=> '$.store.*'"
+```
+
+### Filter Expressions
+```smalltalk
+"Comparison filters"
+SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'price' < 15) asString
+"=> '$.store.book[?(@.price < 15)]'"
+
+"String comparison"
+SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'category' = 'fiction') asString
+"=> '$.store.book[?(@.category == 'fiction')]'"
+```
+
+### Regex Matching
+```smalltalk
+"Basic regex matching"
+SjJsonPath root / 'inventory' / 'mountain_bikes' ? (SjJsonPath current / 'specs' / 'material' =~ 'al') asString
+"=> '$.inventory.mountain_bikes[?(@.specs.material =~ al)]'"
+
+"Case-insensitive regex matching"
+SjJsonPath root / 'inventory' / 'mountain_bikes' ? (SjJsonPath current / 'specs' / 'material' =~ 'al' asJsonPathRegex ignoreCase) asString
+"=> '$.inventory.mountain_bikes[?(@.specs.material =~ (?i)al)]'"
+
+"Complex regex pattern"
+SjJsonPath root / 'users' ? (SjJsonPath current / 'name' =~ (SjJsonPathRegex pattern: '[a-zA-Z]+')) asString
+"=> '$.users[?(@.name =~ [a-zA-Z]+)]'"
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Key features:
 - Array slicing with interval notation (`$.book[0:2]`)
 - Wildcard support for properties and arrays (`$.store.*`, `$.book[*]`)
 - Recursive/descendant search (`$.store..title`)
-- **Filter expressions with comparison and logical operators** (`$.book[?(@.price < 15)]`) 
+- **Filter expressions with comparison and logical operators** (`$.book[?(@.price < 15)]`)
+- **Regex matching in filter expressions** (`$.inventory[?(@.material =~ '(?i)al')]`) 
 
 
 ## Installation
@@ -79,4 +80,23 @@ SjJsonPath root / 'store' / 'book' ? (SjJsonPath current / 'category' = 'fiction
 SjJsonPath root / 'store' / 'book' ? 
     ((SjJsonPath current / 'price' < 15) & (SjJsonPath current / 'category' = 'fiction')) / 'title'
 "=> '$.store.book[?(@.price < 15 && @.category == 'fiction')].title'"
+```
+
+### Regex Matching
+
+```smalltalk
+"Basic regex matching"
+SjJsonPath root / 'inventory' / 'mountain_bikes' ? 
+    (SjJsonPath current / 'specs' / 'material' =~ 'al') / 'model'
+"=> '$.inventory.mountain_bikes[?(@.specs.material =~ al)].model'"
+
+"Case-insensitive regex matching"
+SjJsonPath root / 'inventory' / 'mountain_bikes' ? 
+    (SjJsonPath current / 'specs' / 'material' =~ 'al' asJsonPathRegex ignoreCase) / 'model'
+"=> '$.inventory.mountain_bikes[?(@.specs.material =~ (?i)al)].model'"
+
+"Complex regex pattern"
+SjJsonPath root / 'users' ? 
+    (SjJsonPath current / 'email' =~ (SjJsonPathRegex pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}')) / 'name'
+"=> '$.users[?(@.email =~ [a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})].name'"
 ```

--- a/src/SJsonPath-Core/Object.extension.st
+++ b/src/SJsonPath-Core/Object.extension.st
@@ -9,3 +9,8 @@ Object >> asJsonPathTokenString [
 Object >> asJsonPathExpressionString [
 	^ self asJsonPathTokenString
 ]
+
+{ #category : '*SJsonPath-Core' }
+Object >> asJsonPathRegex [
+	^ SjJsonPathRegex pattern: self asString
+]

--- a/src/SJsonPath-Core/SjJsonPath.class.st
+++ b/src/SJsonPath-Core/SjJsonPath.class.st
@@ -127,3 +127,8 @@ SjJsonPath >> = rightExpression [
 SjJsonPath >> ~= rightExpression [
 	^ SjJsonPathExpression ne: self with: rightExpression
 ]
+
+{ #category : 'filter support' }
+SjJsonPath >> =~ pattern [
+	^ SjJsonPathExpression regexMatch: self with: pattern asJsonPathRegex
+]

--- a/src/SJsonPath-Core/SjJsonPathExpression.class.st
+++ b/src/SJsonPath-Core/SjJsonPathExpression.class.st
@@ -101,6 +101,16 @@ SjJsonPathExpression class >> not: expression [
 		yourself
 ]
 
+{ #category : 'instance creation' }
+SjJsonPathExpression class >> regexMatch: leftExpression with: rightExpression [
+	"Create regex match expression"
+	^ self new
+		type: #infix;
+		operator: '=~';
+		expressions: { leftExpression. rightExpression };
+		yourself
+]
+
 { #category : 'accessing' }
 SjJsonPathExpression >> type [
 	^ type

--- a/src/SJsonPath-Core/SjJsonPathRegex.class.st
+++ b/src/SJsonPath-Core/SjJsonPathRegex.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : 'SjJsonPathRegex',
+	#superclass : 'Object',
+	#instVars : [
+		'pattern'
+	],
+	#category : 'SJsonPath-Core'
+}
+
+{ #category : 'instance creation' }
+SjJsonPathRegex class >> pattern: aString [
+	^ self new pattern: aString; yourself
+]
+
+{ #category : 'accessing' }
+SjJsonPathRegex >> pattern [
+	^ pattern
+]
+
+{ #category : 'accessing' }
+SjJsonPathRegex >> pattern: aString [
+	pattern := aString
+]
+
+{ #category : 'converting' }
+SjJsonPathRegex >> asJsonPathTokenString [
+	^ pattern
+]
+
+{ #category : 'converting' }
+SjJsonPathRegex >> asJsonPathRegex [
+	^ self
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> ignoreCase [
+	^ self class pattern: '(?i)' , pattern
+]

--- a/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
+++ b/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
@@ -83,3 +83,28 @@ SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithNotMultipleConditi
 	path := SjJsonPath root / 'store' / 'book' ? ((SjJsonPath current / 'price' < 15) & (SjJsonPath current / 'category' = 'fiction')) not.
 	self assert: path asString equals: '$.store.book[?(!(@.price < 15 && @.category == ''fiction''))]'
 ]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithRegexMatch [
+	"Test basic regex matching like ?(@.material =~ 'al')"
+	| path |
+	path := SjJsonPath root / 'inventory' / 'mountain_bikes' ? (SjJsonPath current / 'specs' / 'material' =~ 'al').
+	self assert: path asString equals: '$.inventory.mountain_bikes[?(@.specs.material =~ al)]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithRegexIgnoreCase [
+	"Test case-insensitive regex matching like ?(@.material =~ '(?i)al')"
+	| path |
+	path := SjJsonPath root / 'inventory' / 'mountain_bikes' ? (SjJsonPath current / 'specs' / 'material' =~ 'al' asJsonPathRegex ignoreCase).
+	self assert: path asString equals: '$.inventory.mountain_bikes[?(@.specs.material =~ (?i)al)]'
+]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithRegexPattern [
+	"Test regex pattern creation"
+	| regex path |
+	regex := SjJsonPathRegex pattern: '[a-zA-Z]+'.
+	path := SjJsonPath root / 'users' ? (SjJsonPath current / 'name' =~ regex).
+	self assert: path asString equals: '$.users[?(@.name =~ [a-zA-Z]+)]'
+]


### PR DESCRIPTION
- Add SjJsonPathRegex class with pattern: class method for regex pattern creation
- Add ignoreCase method for case-insensitive regex matching with (?i) flag
- Add =~ operator to SjJsonPath for regex matching in filter expressions
- Add regexMatch:with: class method to SjJsonPathExpression for regex operations
- Extend Object with asJsonPathRegex method for automatic pattern wrapping
- Add comprehensive test cases for basic regex, case-insensitive, and pattern creation
- Update CLAUDE.md and README.md with regex matching examples and documentation
- All 14 filter expression tests pass including new regex matching tests

🤖 Generated with [Claude Code](https://claude.ai/code)