### PR TITLE
Added multiple flags support to SjJsonPathRegex 

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,33 @@ SjJsonPath root / 'inventory' / 'mountain_bikes' ?
     (SjJsonPath current / 'specs' / 'material' =~ 'al' asJsonPathRegex ignoreCase) / 'model'
 "=> '$.inventory.mountain_bikes[?(@.specs.material =~ (?i)al)].model'"
 
-"Complex regex pattern"
+"Multiple regex flags"
+SjJsonPath root / 'logs' ? 
+    (SjJsonPath current / 'message' =~ (SjJsonPathRegex pattern: '^error.*') ignoreCase multiLine) / 'timestamp'
+"=> '$.logs[?(@.message =~ (?im)^error.*)].timestamp'"
+
+"All available regex flags"
+SjJsonPath root / 'data' ? 
+    (SjJsonPath current / 'text' =~ (SjJsonPathRegex pattern: 'pattern')
+        ignoreCase        "i - case insensitive"
+        multiLine         "m - ^ and $ match line boundaries"
+        dotMatchesNewline "s - . matches newlines"
+        unicode           "u - unicode support"
+        verbose)          "x - ignore whitespace and comments"
+"=> '$.data[?(@.text =~ (?imsux)pattern)]'"
+
+"Complex regex pattern with flags"
 SjJsonPath root / 'users' ? 
-    (SjJsonPath current / 'email' =~ (SjJsonPathRegex pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}')) / 'name'
-"=> '$.users[?(@.email =~ [a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})].name'"
+    (SjJsonPath current / 'email' =~ (SjJsonPathRegex pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}') ignoreCase) / 'name'
+"=> '$.users[?(@.email =~ (?i)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})].name'"
 ```
+
+#### Available Regex Flags
+
+- `ignoreCase` (i) - Case-insensitive matching
+- `multiLine` (m) - `^` and `$` match line boundaries
+- `dotMatchesNewline` (s) - `.` matches newline characters  
+- `crlfMode` (R) - Use CRLF as line terminator in multi-line mode
+- `swapGreed` (U) - Swap greedy and non-greedy quantifiers
+- `unicode` (u) - Unicode support (enabled by default)
+- `verbose` (x) - Ignore whitespace and allow comments

--- a/src/SJsonPath-Core/SjJsonPathRegex.class.st
+++ b/src/SJsonPath-Core/SjJsonPathRegex.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'SjJsonPathRegex',
 	#superclass : 'Object',
 	#instVars : [
-		'pattern'
+		'pattern',
+		'flags'
 	],
 	#category : 'SJsonPath-Core'
 }
@@ -10,6 +11,18 @@ Class {
 { #category : 'instance creation' }
 SjJsonPathRegex class >> pattern: aString [
 	^ self new pattern: aString; yourself
+]
+
+{ #category : 'instance creation' }
+SjJsonPathRegex class >> pattern: aString flags: aSet [
+	^ self new pattern: aString; flags: aSet; yourself
+]
+
+{ #category : 'initialization' }
+SjJsonPathRegex >> initialize [
+	super initialize.
+	pattern := ''.
+	flags := Set new
 ]
 
 { #category : 'accessing' }
@@ -22,9 +35,22 @@ SjJsonPathRegex >> pattern: aString [
 	pattern := aString
 ]
 
+{ #category : 'accessing' }
+SjJsonPathRegex >> flags [
+	^ flags
+]
+
+{ #category : 'accessing' }
+SjJsonPathRegex >> flags: aSet [
+	flags := aSet
+]
+
 { #category : 'converting' }
 SjJsonPathRegex >> asJsonPathTokenString [
-	^ pattern
+	| sortedFlags |
+	flags ifEmpty: [ ^ self pattern ].
+	sortedFlags := flags asSortedCollection.
+	^ '(?{1}){2}' format: {('' join: sortedFlags). self pattern}
 ]
 
 { #category : 'converting' }
@@ -32,7 +58,42 @@ SjJsonPathRegex >> asJsonPathRegex [
 	^ self
 ]
 
+{ #category : 'private' }
+SjJsonPathRegex >> cloneWithFlagAdded: aFlag [
+	^ self class pattern: self pattern flags: (self flags add: aFlag; yourself)
+]
+
 { #category : 'utilities' }
 SjJsonPathRegex >> ignoreCase [
-	^ self class pattern: '(?i)' , pattern
+	^ self cloneWithFlagAdded: 'i'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> multiLine [
+	^ self cloneWithFlagAdded: 'm'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> dotMatchesNewline [
+	^ self cloneWithFlagAdded: 's'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> crlfMode [
+	^ self cloneWithFlagAdded: 'R'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> swapGreed [
+	^ self cloneWithFlagAdded: 'U'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> unicode [
+	^ self cloneWithFlagAdded: 'u'
+]
+
+{ #category : 'utilities' }
+SjJsonPathRegex >> verbose [
+	^ self cloneWithFlagAdded: 'x'
 ]

--- a/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
+++ b/src/SJsonPath-Tests/SjJsonPathFilterExpressionTestCase.class.st
@@ -108,3 +108,12 @@ SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithRegexPattern [
 	path := SjJsonPath root / 'users' ? (SjJsonPath current / 'name' =~ regex).
 	self assert: path asString equals: '$.users[?(@.name =~ [a-zA-Z]+)]'
 ]
+
+{ #category : 'testing' }
+SjJsonPathFilterExpressionTestCase >> testFilterExpressionWithRegexIgnoreCaseAndMultipleFlags [
+	"Test regex with multiple flags in filter expression"
+	| path |
+	path := SjJsonPath root / 'logs' ? (SjJsonPath current / 'message' =~ (SjJsonPathRegex pattern: '^error.*') ignoreCase multiLine).
+	self assert: path asString equals: '$.logs[?(@.message =~ (?im)^error.*)]'
+]
+

--- a/src/SJsonPath-Tests/SjJsonPathRegexTestCase.class.st
+++ b/src/SJsonPath-Tests/SjJsonPathRegexTestCase.class.st
@@ -1,0 +1,142 @@
+Class {
+	#name : 'SjJsonPathRegexTestCase',
+	#superclass : 'TestCase',
+	#category : 'SJsonPath-Tests',
+	#package : 'SJsonPath-Tests'
+}
+
+{ #category : 'testing - basic' }
+SjJsonPathRegexTestCase >> testBasicRegexPattern [
+	"Test basic SjJsonPathRegex pattern creation and conversion"
+	| regex |
+	regex := SjJsonPathRegex pattern: 'test'.
+	self assert: regex asJsonPathTokenString equals: 'test'.
+	self assert: regex pattern equals: 'test'.
+	self assert: regex flags isEmpty
+]
+
+{ #category : 'testing - basic' }
+SjJsonPathRegexTestCase >> testEmptyRegexPattern [
+	"Test empty pattern handling"
+	| regex |
+	regex := SjJsonPathRegex pattern: ''.
+	self assert: regex asJsonPathTokenString equals: ''.
+	self assert: regex flags isEmpty
+]
+
+{ #category : 'testing - basic' }
+SjJsonPathRegexTestCase >> testRegexFactoryMethod [
+	"Test class-side factory method with flags"
+	| regex |
+	regex := SjJsonPathRegex pattern: 'test' flags: (Set with: 'i' with: 'm').
+	self assert: regex asJsonPathTokenString equals: '(?im)test'.
+	self assert: regex flags size equals: 2
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexIgnoreCaseFlag [
+	"Test ignoreCase flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') ignoreCase.
+	self assert: regex asJsonPathTokenString equals: '(?i)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexMultiLineFlag [
+	"Test multiLine flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') multiLine.
+	self assert: regex asJsonPathTokenString equals: '(?m)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexDotMatchesNewlineFlag [
+	"Test dotMatchesNewline flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') dotMatchesNewline.
+	self assert: regex asJsonPathTokenString equals: '(?s)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexCrlfModeFlag [
+	"Test crlfMode flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') crlfMode.
+	self assert: regex asJsonPathTokenString equals: '(?R)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexSwapGreedFlag [
+	"Test swapGreed flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') swapGreed.
+	self assert: regex asJsonPathTokenString equals: '(?U)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexUnicodeFlag [
+	"Test unicode flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') unicode.
+	self assert: regex asJsonPathTokenString equals: '(?u)test'
+]
+
+{ #category : 'testing - single flags' }
+SjJsonPathRegexTestCase >> testRegexVerboseFlag [
+	"Test verbose flag addition"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') verbose.
+	self assert: regex asJsonPathTokenString equals: '(?x)test'
+]
+
+{ #category : 'testing - multiple flags' }
+SjJsonPathRegexTestCase >> testRegexMultipleFlagsOrdered [
+	"Test multiple flags are properly sorted"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test') 
+		verbose 
+		ignoreCase 
+		multiLine.
+	self assert: regex asJsonPathTokenString equals: '(?imx)test'
+]
+
+{ #category : 'testing - multiple flags' }
+SjJsonPathRegexTestCase >> testRegexAllFlags [
+	"Test all available flags together"
+	| regex |
+	regex := (SjJsonPathRegex pattern: 'test')
+		crlfMode
+		ignoreCase
+		multiLine
+		dotMatchesNewline
+		swapGreed
+		unicode
+		verbose.
+	self assert: regex asJsonPathTokenString equals: '(?RUimsux)test'
+]
+
+{ #category : 'testing - multiple flags' }
+SjJsonPathRegexTestCase >> testRegexFlagConsistency [
+	"Test that same flags produce same results"
+	| regex1 regex2 |
+	regex1 := (SjJsonPathRegex pattern: 'test') ignoreCase multiLine.
+	regex2 := (SjJsonPathRegex pattern: 'test') multiLine ignoreCase.
+	self assert: regex1 asJsonPathTokenString equals: regex2 asJsonPathTokenString.
+	self assert: regex1 asJsonPathTokenString equals: '(?im)test'
+]
+
+{ #category : 'testing - in filter expressions' }
+SjJsonPathRegexTestCase >> testComplexRegexInFilter [
+	"Test complex regex pattern in filter expression"
+	| path |
+	path := SjJsonPath root / 'products' ? (SjJsonPath current / 'code' =~ (SjJsonPathRegex pattern: '\d{3}-[A-Z]{2}') ignoreCase).
+	self assert: path asString equals: '$.products[?(@.code =~ (?i)\d{3}-[A-Z]{2})]'
+]
+
+{ #category : 'testing - in filter expressions' }
+SjJsonPathRegexTestCase >> testMultiFlagRegexInFilter [
+	"Test multi-flag regex in filter expression"
+	| path |
+	path := SjJsonPath root / 'logs' ? (SjJsonPath current / 'message' =~ (SjJsonPathRegex pattern: '^error.*') ignoreCase multiLine).
+	self assert: path asString equals: '$.logs[?(@.message =~ (?im)^error.*)]'
+]


### PR DESCRIPTION
This pull request significantly enhances regex support in the SJsonPath library by introducing a flexible, flag-based API for JSONPath regex expressions. It adds a new `SjJsonPathRegexTestCase` test class with comprehensive coverage, updates documentation and usage examples, and refactors the core regex implementation to support multiple flags in a composable way.

**Regex Functionality Enhancements:**

* Refactored `SjJsonPathRegex` to store regex flags as a `Set`, allowing multiple flags to be combined and ensuring output consistency. Added new instance methods for all standard regex flags (ignoreCase, multiLine, dotMatchesNewline, crlfMode, swapGreed, unicode, verbose), and a private `cloneWithFlagAdded:` method for composability. Updated `asJsonPathTokenString` to format flags correctly. [[1]](diffhunk://#diff-5f1c29c0445bee3d18245b1db34e1f368b3909a539f6dc07b6a072097d38b659L5-R6) [[2]](diffhunk://#diff-5f1c29c0445bee3d18245b1db34e1f368b3909a539f6dc07b6a072097d38b659R16-R27) [[3]](diffhunk://#diff-5f1c29c0445bee3d18245b1db34e1f368b3909a539f6dc07b6a072097d38b659R38-R98)
* Added a class-side factory method `pattern:flags:` to `SjJsonPathRegex` for direct creation with flags.

**Testing Improvements:**

* Added a new test class `SjJsonPathRegexTestCase` with extensive tests covering basic regex creation, each individual flag, combinations of flags, flag order consistency, and integration with filter expressions.
* Extended `SjJsonPathFilterExpressionTestCase` with a test for filter expressions using regexes with multiple flags.

**Documentation and Example Updates:**

* Updated `CLAUDE.md` and `README.md` to document the new regex flag API, available flags, and added/changed code examples to demonstrate multi-flag regex usage in JSONPath expressions. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L14-R14) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R27) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R67) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L78-R98) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R115) [[6]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L109-R136) [[7]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L162-R192) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R127)

**Test Suite Integration:**

* Ensured the new `SjJsonPathRegexTestCase` is included in documentation and test suite instructions.

These changes make regex handling in SJsonPath more powerful, composable, and user-friendly, while providing thorough test coverage and clear documentation.